### PR TITLE
Fix `os2` breakage, `-vet`

### DIFF
--- a/buffer_util.odin
+++ b/buffer_util.odin
@@ -28,8 +28,6 @@ case [][4]i16:
 */
 package gltf2
 
-import "core:mem"
-
 // All accessor type and component type combinations
 Buffer_Slice :: union {
     []u8,
@@ -105,113 +103,113 @@ buffer_slice :: proc(data: ^Data, accessor_index: Integer) -> Buffer_Slice {
         case .Scalar:
             switch accessor.component_type {
             case .Unsigned_Byte:
-                return (transmute([^]u8)start_ptr)[:accessor.count]
+                return (cast([^]u8)start_ptr)[:accessor.count]
             case .Byte:
-                return (transmute([^]i8)start_ptr)[:accessor.count]
+                return (cast([^]i8)start_ptr)[:accessor.count]
             case .Short:
-                return (transmute([^]i16)start_ptr)[:accessor.count]
+                return (cast([^]i16)start_ptr)[:accessor.count]
             case .Unsigned_Short:
-                return (transmute([^]u16)start_ptr)[:accessor.count]
+                return (cast([^]u16)start_ptr)[:accessor.count]
             case .Unsigned_Int:
-                return (transmute([^]u32)start_ptr)[:accessor.count]
+                return (cast([^]u32)start_ptr)[:accessor.count]
             case .Float:
-                return (transmute([^]f32)start_ptr)[:accessor.count]
+                return (cast([^]f32)start_ptr)[:accessor.count]
             }
 
         case .Vector2:
             switch accessor.component_type {
             case .Unsigned_Byte:
-                return (transmute([^][2]u8)start_ptr)[:accessor.count]
+                return (cast([^][2]u8)start_ptr)[:accessor.count]
             case .Byte:
-                return (transmute([^][2]i8)start_ptr)[:accessor.count]
+                return (cast([^][2]i8)start_ptr)[:accessor.count]
             case .Short:
-                return (transmute([^][2]i16)start_ptr)[:accessor.count]
+                return (cast([^][2]i16)start_ptr)[:accessor.count]
             case .Unsigned_Short:
-                return (transmute([^][2]u16)start_ptr)[:accessor.count]
+                return (cast([^][2]u16)start_ptr)[:accessor.count]
             case .Unsigned_Int:
-                return (transmute([^][2]u32)start_ptr)[:accessor.count]
+                return (cast([^][2]u32)start_ptr)[:accessor.count]
             case .Float:
-                return (transmute([^][2]f32)start_ptr)[:accessor.count]
+                return (cast([^][2]f32)start_ptr)[:accessor.count]
             }
 
         case .Vector3:
             switch accessor.component_type {
             case .Unsigned_Byte:
-                return (transmute([^][3]u8)start_ptr)[:accessor.count]
+                return (cast([^][3]u8)start_ptr)[:accessor.count]
             case .Byte:
-                return (transmute([^][3]i8)start_ptr)[:accessor.count]
+                return (cast([^][3]i8)start_ptr)[:accessor.count]
             case .Short:
-                return (transmute([^][3]i16)start_ptr)[:accessor.count]
+                return (cast([^][3]i16)start_ptr)[:accessor.count]
             case .Unsigned_Short:
-                return (transmute([^][3]u16)start_ptr)[:accessor.count]
+                return (cast([^][3]u16)start_ptr)[:accessor.count]
             case .Unsigned_Int:
-                return (transmute([^][3]u32)start_ptr)[:accessor.count]
+                return (cast([^][3]u32)start_ptr)[:accessor.count]
             case .Float:
-                return (transmute([^][3]f32)start_ptr)[:accessor.count]
+                return (cast([^][3]f32)start_ptr)[:accessor.count]
             }
 
         case .Vector4:
             switch accessor.component_type {
             case .Unsigned_Byte:
-                return (transmute([^][4]u8)start_ptr)[:accessor.count]
+                return (cast([^][4]u8)start_ptr)[:accessor.count]
             case .Byte:
-                return (transmute([^][4]i8)start_ptr)[:accessor.count]
+                return (cast([^][4]i8)start_ptr)[:accessor.count]
             case .Short:
-                return (transmute([^][4]i16)start_ptr)[:accessor.count]
+                return (cast([^][4]i16)start_ptr)[:accessor.count]
             case .Unsigned_Short:
-                return (transmute([^][4]u16)start_ptr)[:accessor.count]
+                return (cast([^][4]u16)start_ptr)[:accessor.count]
             case .Unsigned_Int:
-                return (transmute([^][4]u32)start_ptr)[:accessor.count]
+                return (cast([^][4]u32)start_ptr)[:accessor.count]
             case .Float:
-                return (transmute([^][4]f32)start_ptr)[:accessor.count]
+                return (cast([^][4]f32)start_ptr)[:accessor.count]
             }
 
         case .Matrix2:
             switch accessor.component_type {
             case .Unsigned_Byte:
-                return (transmute([^]matrix[2, 2]u8)start_ptr)[:accessor.count]
+                return (cast([^]matrix[2, 2]u8)start_ptr)[:accessor.count]
             case .Byte:
-                return (transmute([^]matrix[2, 2]i8)start_ptr)[:accessor.count]
+                return (cast([^]matrix[2, 2]i8)start_ptr)[:accessor.count]
             case .Short:
-                return (transmute([^]matrix[2, 2]i16)start_ptr)[:accessor.count]
+                return (cast([^]matrix[2, 2]i16)start_ptr)[:accessor.count]
             case .Unsigned_Short:
-                return (transmute([^]matrix[2, 2]u16)start_ptr)[:accessor.count]
+                return (cast([^]matrix[2, 2]u16)start_ptr)[:accessor.count]
             case .Unsigned_Int:
-                return (transmute([^]matrix[2, 2]u32)start_ptr)[:accessor.count]
+                return (cast([^]matrix[2, 2]u32)start_ptr)[:accessor.count]
             case .Float:
-                return (transmute([^]matrix[2, 2]f32)start_ptr)[:accessor.count]
+                return (cast([^]matrix[2, 2]f32)start_ptr)[:accessor.count]
             }
 
         case .Matrix3:
             switch accessor.component_type {
             case .Unsigned_Byte:
-                return (transmute([^]matrix[3, 3]u8)start_ptr)[:accessor.count]
+                return (cast([^]matrix[3, 3]u8)start_ptr)[:accessor.count]
             case .Byte:
-                return (transmute([^]matrix[3, 3]i8)start_ptr)[:accessor.count]
+                return (cast([^]matrix[3, 3]i8)start_ptr)[:accessor.count]
             case .Short:
-                return (transmute([^]matrix[3, 3]i16)start_ptr)[:accessor.count]
+                return (cast([^]matrix[3, 3]i16)start_ptr)[:accessor.count]
             case .Unsigned_Short:
-                return (transmute([^]matrix[3, 3]u16)start_ptr)[:accessor.count]
+                return (cast([^]matrix[3, 3]u16)start_ptr)[:accessor.count]
             case .Unsigned_Int:
-                return (transmute([^]matrix[3, 3]u32)start_ptr)[:accessor.count]
+                return (cast([^]matrix[3, 3]u32)start_ptr)[:accessor.count]
             case .Float:
-                return (transmute([^]matrix[3, 3]f32)start_ptr)[:accessor.count]
+                return (cast([^]matrix[3, 3]f32)start_ptr)[:accessor.count]
             }
 
         case .Matrix4:
             switch accessor.component_type {
             case .Unsigned_Byte:
-                return (transmute([^]matrix[4, 4]u8)start_ptr)[:accessor.count]
+                return (cast([^]matrix[4, 4]u8)start_ptr)[:accessor.count]
             case .Byte:
-                return (transmute([^]matrix[4, 4]i8)start_ptr)[:accessor.count]
+                return (cast([^]matrix[4, 4]i8)start_ptr)[:accessor.count]
             case .Short:
-                return (transmute([^]matrix[4, 4]i16)start_ptr)[:accessor.count]
+                return (cast([^]matrix[4, 4]i16)start_ptr)[:accessor.count]
             case .Unsigned_Short:
-                return (transmute([^]matrix[4, 4]u16)start_ptr)[:accessor.count]
+                return (cast([^]matrix[4, 4]u16)start_ptr)[:accessor.count]
             case .Unsigned_Int:
-                return (transmute([^]matrix[4, 4]u32)start_ptr)[:accessor.count]
+                return (cast([^]matrix[4, 4]u32)start_ptr)[:accessor.count]
             case .Float:
-                return (transmute([^]matrix[4, 4]f32)start_ptr)[:accessor.count]
+                return (cast([^]matrix[4, 4]f32)start_ptr)[:accessor.count]
             }
 
         }

--- a/gltf.odin
+++ b/gltf.odin
@@ -203,7 +203,7 @@ uri_parse :: proc(uri: Uri, gltf_dir: string) -> Uri {
         if !ok {
             return uri
         }
-        return cast([]byte)bytes
+        return bytes
     }
 
     type := str_data[:type_idx]

--- a/gltf.odin
+++ b/gltf.odin
@@ -1,5 +1,6 @@
 package gltf2
 
+import "base:runtime"
 import "core:encoding/base64"
 import "core:encoding/json"
 import "core:fmt"
@@ -25,8 +26,8 @@ load_from_file :: proc(file_name: string, allocator := context.allocator) -> (da
         return nil, GLTF_Error{type = .No_File, proc_name = #procedure, param = {name = file_name}}
     }
 
-    file_content, ok := os.read_entire_file(file_name, allocator)
-    if !ok {
+    file_content, file_err := os.read_entire_file(file_name, allocator)
+    if file_err != nil {
         return nil, GLTF_Error{type = .Cant_Read_File, proc_name = #procedure, param = {name = file_name}}
     }
 
@@ -99,10 +100,10 @@ parse :: proc(file_content: []byte, opt := Options{}, allocator := context.alloc
     data.asset = asset_parse(parsed_object.(json.Object)) or_return
     data.accessors = accessors_parse(parsed_object.(json.Object)) or_return
     data.animations = animations_parse(parsed_object.(json.Object)) or_return
-    data.buffers = buffers_parse(parsed_object.(json.Object), opt.gltf_dir) or_return
+    data.buffers = buffers_parse(parsed_object.(json.Object), opt.gltf_dir, allocator) or_return
     data.buffer_views = buffer_views_parse(parsed_object.(json.Object)) or_return
     data.cameras = cameras_parse(parsed_object.(json.Object)) or_return
-    data.images = images_parse(parsed_object.(json.Object), opt.gltf_dir) or_return
+    data.images = images_parse(parsed_object.(json.Object), opt.gltf_dir, allocator) or_return
     data.materials = materials_parse(parsed_object.(json.Object)) or_return
     data.meshes = meshes_parse(parsed_object.(json.Object)) or_return
     data.nodes = nodes_parse(parsed_object.(json.Object)) or_return
@@ -187,7 +188,7 @@ extensions_names_free :: proc(names: []string) {
 }
 
 @(require_results)
-uri_parse :: proc(uri: Uri, gltf_dir: string) -> Uri {
+uri_parse :: proc(uri: Uri, gltf_dir: string, allocator: runtime.Allocator) -> Uri {
     if uri == nil {
         return uri
     }
@@ -199,8 +200,8 @@ uri_parse :: proc(uri: Uri, gltf_dir: string) -> Uri {
     type_idx := strings.index_rune(str_data, ':')
     if type_idx == -1 {
         // Check if this is possible file and if so load it
-        bytes, ok := os.read_entire_file(fmt.tprintf("%s/%s", gltf_dir, str_data))
-        if !ok {
+        bytes, err := os.read_entire_file(fmt.tprintf("%s/%s", gltf_dir, str_data), allocator)
+        if err != nil {
             return uri
         }
         return bytes
@@ -779,7 +780,7 @@ animation_samplers_parse :: proc(array: json.Array) -> (res: []Animation_Sampler
     Buffers parsing
 */
 @(require_results)
-buffers_parse :: proc(object: json.Object, gltf_dir: string) -> (res: []Buffer, err: Error) {
+buffers_parse :: proc(object: json.Object, gltf_dir: string, allocator: runtime.Allocator) -> (res: []Buffer, err: Error) {
     if BUFFERS_KEY not_in object {
         return
     }
@@ -801,7 +802,7 @@ buffers_parse :: proc(object: json.Object, gltf_dir: string) -> (res: []Buffer, 
                 res[idx].name = v.(string)
 
             case "uri":
-                res[idx].uri = uri_parse(v.(string), gltf_dir)
+                res[idx].uri = uri_parse(v.(string), gltf_dir, allocator)
 
             case EXTENSIONS_KEY:
                 res[idx].extensions = v
@@ -1064,7 +1065,7 @@ perspective_camera_parse :: proc(object: json.Object) -> (res: Perspective_Camer
     Images parsing
 */
 @(require_results)
-images_parse :: proc(object: json.Object, gltf_dir: string) -> (res: []Image, err: Error) {
+images_parse :: proc(object: json.Object, gltf_dir: string, allocator: runtime.Allocator) -> (res: []Image, err: Error) {
     if IMAGES_KEY not_in object {
         return
     }
@@ -1093,7 +1094,7 @@ images_parse :: proc(object: json.Object, gltf_dir: string) -> (res: []Image, er
                 res[idx].name = v.(string)
 
             case "uri":
-                res[idx].uri = uri_parse(v.(string), gltf_dir)
+                res[idx].uri = uri_parse(v.(string), gltf_dir, allocator)
 
             case EXTENSIONS_KEY:
                 res[idx].extensions = v


### PR DESCRIPTION
The newest version of Odin replaced the old `os` package with `os2`. Plus some minor changes to make it pass `-vet`.