### PR TITLE
filepath dir does not allocate so do not delete

### DIFF
--- a/gltf.odin
+++ b/gltf.odin
@@ -32,7 +32,6 @@ load_from_file :: proc(file_name: string, allocator := context.allocator) -> (da
     }
 
     gltf_dir := filepath.dir(file_name)
-    defer delete(gltf_dir)
 
     options := Options {
         delete_content = true,


### PR DESCRIPTION
Was quickly testing latest Odin release and noticed gltf2 crashes trying to free a variable which isn't allocated (probably was before?)

Removing the delete fixes the problem so that's what this PR does