### PR TITLE
Fix compilation error on latest Odin version

### DIFF
--- a/gltf.odin
+++ b/gltf.odin
@@ -222,7 +222,11 @@ uri_parse :: proc(uri: Uri, gltf_dir: string, allocator: runtime.Allocator) -> U
 
         switch encoding {
         case "base64":
-            return base64.decode(str_data[encoding_end_idx + 1:])
+            data: []u8
+            if data, err := base64.decode(str_data[encoding_end_idx + 1:]); err != nil {
+                return uri
+            }
+            return data
         }
     }
 


### PR DESCRIPTION
This makes a small change to bring it in line with a small API change in the latest version of Odin with the `base64.decode` procedure.