### PR TITLE
Fix base64 API breakage

### DIFF
--- a/gltf.odin
+++ b/gltf.odin
@@ -222,7 +222,11 @@ uri_parse :: proc(uri: Uri, gltf_dir: string, allocator: runtime.Allocator) -> U
 
         switch encoding {
         case "base64":
-            return base64.decode(str_data[encoding_end_idx + 1:])
+            decoded, err := base64.decode(str_data[encoding_end_idx + 1:])
+            if err != nil {
+                return uri
+            }
+            return decoded
         }
     }
 


### PR DESCRIPTION
As of https://github.com/odin-lang/Odin/commit/82a18797b4f54b5ece243c8aa28c649911243a29, `base64.decode` requires you to handle the error.